### PR TITLE
Corrected timeline repr to include module

### DIFF
--- a/animatplot/timeline.py
+++ b/animatplot/timeline.py
@@ -8,8 +8,8 @@ class Timeline:
     Parameters
     ----------
     t : array_like
-            gets converted to a numpy array representing
-            the time at each frame of the animation
+        Gets converted to a numpy array representing
+        the time at each frame of the animation
     units : str, optional
         the units the time is measured in.
     fps : float, optional
@@ -43,7 +43,8 @@ class Timeline:
     def __repr__(self):
         time = repr(self.t)
         units = repr(self.units)
-        return "Timeline(t={}, units={}, fps={})".format(time, units, self.fps)
+        return "animatplot.animation.Timeline(t={}, units={}, fps={})"\
+            .format(time, units, self.fps)
 
     def __len__(self):
         return self._len

--- a/tests/test_timeline.py
+++ b/tests/test_timeline.py
@@ -1,14 +1,18 @@
 import pytest
 import numpy as np
-from numpy import arange, array
 from animatplot.timeline import Timeline
+
+# Needed for eval
+from numpy import array
+import animatplot
 
 
 def test_repr():
-    times = arange(0, 5, .5)
+    times = np.arange(0, 5, .5)
     t = Timeline(times)
 
-    representation = "Timeline(t=array([0. , 0.5, 1. , 1.5, 2. , 2.5, " \
+    representation = "animatplot.animation.Timeline(" \
+                     "t=array([0. , 0.5, 1. , 1.5, 2. , 2.5, " \
                      "3. , 3.5, 4. , 4.5]), units='', fps=10)"
     assert repr(t) == representation
     assert isinstance(eval(repr(t)), Timeline)


### PR DESCRIPTION
Very small change to the repr of the timeline object, so that the namespace of the Timeline class is specified.